### PR TITLE
Adding node-aware filepaths

### DIFF
--- a/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
@@ -44,7 +44,6 @@ public class UploadAsset implements Serializable {
     RemoteInputStream result = workspace.act(new MasterToSlaveFileCallable<RemoteInputStream>() {
         @Override
         public RemoteInputStream invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-            // Perform node-specific logic here
             FileInputStream input = new FileInputStream(workspace.child(localFilePath).getRemote());
             return new RemoteInputStream(input, Flag.GREEDY);
         }

--- a/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
@@ -40,24 +40,17 @@ public class UploadAsset implements Serializable {
   }
 
   public InputStream toStream(FilePath workspace) throws IOException, InterruptedException {
-    final String localFilePath = this.filePath;
-    RemoteInputStream result = workspace.act(new MasterToSlaveFileCallable<RemoteInputStream>() {
-        @Override
-        public RemoteInputStream invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
-            FileInputStream input = new FileInputStream(workspace.child(localFilePath).getRemote());
-            return new RemoteInputStream(input, Flag.GREEDY);
-        }
-    });
-    return result;
+    return workspace.child(filePath).read();
   }
 
+
   public boolean isMissing(FilePath workspace) {
-      try {
-          FilePath file = workspace.child(this.filePath);
-          return !file.exists() || file.isDirectory();
-      } catch (IOException | InterruptedException e) {
-          // If an exception occurs, assume the file is missing
-          return true;
-      }
+    try {
+      FilePath file = workspace.child(this.filePath);
+      return !file.exists() || file.isDirectory();
+    } catch (IOException | InterruptedException e) {
+      // If an exception occurs, assume the file is missing
+      return true;
+    }
   }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
@@ -1,10 +1,18 @@
 package io.jenkins.plugins.github.release;
 
+import hudson.FilePath;
 import hudson.Util;
+import hudson.remoting.RemoteInputStream;
+import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
+import hudson.remoting.RemoteInputStream.Flag;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 
 public class UploadAsset implements Serializable {
@@ -31,11 +39,26 @@ public class UploadAsset implements Serializable {
     this.filePath = Util.fixEmptyAndTrim(filePath);
   }
 
-  public File toFile() {
-    return new File(this.filePath);
+  public InputStream toStream(FilePath workspace) throws IOException, InterruptedException {
+    final String localFilePath = this.filePath;
+    RemoteInputStream result = workspace.act(new MasterToSlaveFileCallable<RemoteInputStream>() {
+        @Override
+        public RemoteInputStream invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+            // Perform node-specific logic here
+            FileInputStream input = new FileInputStream(workspace.child(localFilePath).getRemote());
+            return new RemoteInputStream(input, Flag.GREEDY);
+        }
+    });
+    return result;
   }
 
-  public boolean isMissing() {
-    return !toFile().isFile();
+  public boolean isMissing(FilePath workspace) {
+      try {
+          FilePath file = workspace.child(this.filePath);
+          return !file.exists() || file.isDirectory();
+      } catch (IOException | InterruptedException e) {
+          // If an exception occurs, assume the file is missing
+          return true;
+      }
   }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
@@ -2,15 +2,9 @@ package io.jenkins.plugins.github.release;
 
 import hudson.FilePath;
 import hudson.Util;
-import hudson.remoting.RemoteInputStream;
-import hudson.remoting.VirtualChannel;
-import jenkins.MasterToSlaveFileCallable;
-import hudson.remoting.RemoteInputStream.Flag;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;

--- a/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStepExecution.java
@@ -9,6 +9,7 @@ import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -57,11 +58,13 @@ public class UploadReleaseAssetStepExecution extends SynchronousStepExecution<Vo
 
     for (UploadAsset uploadAsset : this.step.uploadAssets) {
       taskListener.getLogger().printf("Started uploading %s%n", uploadAsset.filePath);
-      release.uploadAsset(
-          uploadAsset.filePath,
-          uploadAsset.toStream(workspace),
-          uploadAsset.contentType
-      );
+      try (InputStream assetStream = uploadAsset.toStream(workspace)) {
+        release.uploadAsset(
+            uploadAsset.filePath,
+            assetStream,
+            uploadAsset.contentType
+        );
+      }
       taskListener.getLogger().printf("Finished uploading %s%n", uploadAsset.filePath);
     }
 


### PR DESCRIPTION
Adds node-aware file paths to allow non-controller environments to upload release assets.

Fixes https://github.com/jenkinsci/github-release-plugin/issues/8 

This PR replaces the existing File constructor logic with workspace-aware FilePaths. The two main changes are in the UploadAsset.java class. The "isMissing" function was modified to:

```
public boolean isMissing(FilePath workspace) {
      try {
          FilePath file = workspace.child(this.filePath);
          return !file.exists() || file.isDirectory();
      } catch (IOException | InterruptedException e) {
          // If an exception occurs, assume the file is missing
          return true;
      }
  }
```

As well as the "toFile" function, renamed to "toStream", which now returns an InputStream instead:

```
public InputStream toStream(FilePath workspace) throws IOException, InterruptedException {
    final String localFilePath = this.filePath;
    RemoteInputStream result = workspace.act(new MasterToSlaveFileCallable<RemoteInputStream>() {
        @Override
        public RemoteInputStream invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
            FileInputStream input = new FileInputStream(workspace.child(localFilePath).getRemote());
            return new RemoteInputStream(input, Flag.GREEDY);
        }
    });
    return result;
  }
  ```
  
The FilePath workspace is retrieved from a context key in the executor the same way the 'TaskListener' and other items are retrieved.