### PR TITLE
Fixing filenames of uploaded assets

### DIFF
--- a/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStepExecution.java
@@ -9,6 +9,7 @@ import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -60,7 +61,7 @@ public class UploadReleaseAssetStepExecution extends SynchronousStepExecution<Vo
       taskListener.getLogger().printf("Started uploading %s%n", uploadAsset.filePath);
       try (InputStream assetStream = uploadAsset.toStream(workspace)) {
         release.uploadAsset(
-            uploadAsset.filePath,
+            new File(uploadAsset.filePath).getName(),
             assetStream,
             uploadAsset.contentType
         );


### PR DESCRIPTION
Fix asset upload filename issue introduced in PR #10

When uploading assets to GitHub releases, the full file path was being used as the filename instead of just the basename. This resulted in filenames like `C.path.to.workspace.myproject.FullPackage.zip` instead of `FullPackage.zip`. 

Fixes reported [issue ](https://github.com/jenkinsci/github-release-plugin/issues/22)

The issue was caused by passing `uploadAsset.filePath` directly to `GHRelease.uploadAsset()`. The fix uses `new File(uploadAsset.filePath).getName()` to extract just the filename, restoring the behavior from before PR #10.

### Testing done

Tested asset uploads from both Jenkins controller and agents, verifying that uploaded filenames now correctly show only the basename (e.g., `FullPackage.zip`) instead of the full path.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch**
(right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog
entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or
the issue is fixed

Fixes the regression introduced in (https://github.com/jenkinsci/github-release-plugin/pull/10)