### PR TITLE
Feat/add generate release notes automatic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,5 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'windows', jdk: 21],
 ])

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ createGitHubRelease(
 )
 ```
 
+#### Create a release with auto-generated release notes
+
+When `generateReleaseNotes` is set to `true`, GitHub automatically generates
+release notes from merged pull requests since the last published release.
+
+```groovy
+createGitHubRelease(
+        credentialId: 'a1234',
+        repository: 'jcustenborder/xjc-kafka-connect-plugin',
+        tag: 'v1.3.0',
+        commitish: '17b5676aaab28e334c0a9befc86e7615a7539c32',
+        generateReleaseNotes: true
+)
+```
+
+If `bodyText` or `bodyFile` is also specified, that text will be prepended to the
+automatically generated notes.
+
 ### listGitHubReleases
 
 Step is used to list the releases in a GitHub repository.

--- a/pom.xml
+++ b/pom.xml
@@ -1,123 +1,121 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>6.2211.v27f680c93c53</version>
-        <relativePath/>
-    </parent>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>6.2211.v27f680c93c53</version>
+    <relativePath />
+  </parent>
 
-    <properties>
-        <jenkins.version>2.555.3</jenkins.version>
-        <changelist>999999-SNAPSHOT</changelist>
-    </properties>
+  <groupId>io.jenkins.plugins</groupId>
+  <artifactId>github-release</artifactId>
+  <version>${changelist}</version>
+  <packaging>hpi</packaging>
+  <name>Github Release Plugin</name>
+  <url>https://github.com/jenkinsci/github-release-plugin</url>
 
-    <groupId>io.jenkins.plugins</groupId>
-    <artifactId>github-release</artifactId>
-    <version>${changelist}</version>
-    <packaging>hpi</packaging>
-    <name>Github Release Plugin</name>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>jcustenborder</id>
+      <name>Jeremy Custenborder</name>
+      <email>jcustenborder@gmail.com</email>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>https://github.com/jenkinsci/github-release-plugin.git</connection>
+    <developerConnection>https://git@github.com/jenkinsci/github-release-plugin.git</developerConnection>
+    <tag>HEAD</tag>
     <url>https://github.com/jenkinsci/github-release-plugin</url>
+  </scm>
 
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
+  <properties>
+    <jenkins.version>2.555.3</jenkins.version>
+    <changelist>999999-SNAPSHOT</changelist>
+  </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.555.x</artifactId>
-                <version>6751.v745d6a_31066a_</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>github-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>script-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>plain-credentials</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-basic-steps</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-standalone</artifactId>
-            <version>3.12.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.555.x</artifactId>
+        <version>6751.v745d6a_31066a_</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <developers>
-        <developer>
-            <id>jcustenborder</id>
-            <name>Jeremy Custenborder</name>
-            <email>jcustenborder@gmail.com</email>
-        </developer>
-    </developers>
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>plain-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>3.12.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <scm>
-        <connection>https://github.com/jenkinsci/github-release-plugin.git</connection>
-        <developerConnection>https://git@github.com/jenkinsci/github-release-plugin.git
-        </developerConnection>
-        <url>https://github.com/jenkinsci/github-release-plugin</url>
-        <tag>HEAD</tag>
-    </scm>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.73</version>
+        <version>6.2211.v27f680c93c53</version>
         <relativePath/>
     </parent>
 
     <properties>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.555.3</jenkins.version>
         <changelist>999999-SNAPSHOT</changelist>
     </properties>
 
@@ -35,8 +35,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2543.vfb_1a_5fb_9496d</version>
+                <artifactId>bom-2.555.x</artifactId>
+                <version>6751.v745d6a_31066a_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/io/jenkins/plugins/github/GitHubParameters.java
+++ b/src/main/java/io/jenkins/plugins/github/GitHubParameters.java
@@ -1,10 +1,11 @@
 package io.jenkins.plugins.github;
 
 public interface GitHubParameters {
-  String getCredentialId();
-  void setCredentialId(String credentialId);
+    String getCredentialId();
 
+    void setCredentialId(String credentialId);
 
-  String getGithubServer();
-  void setGithubServer(String gitHubServer);
+    String getGithubServer();
+
+    void setGithubServer(String gitHubServer);
 }

--- a/src/main/java/io/jenkins/plugins/github/GitHubUtils.java
+++ b/src/main/java/io/jenkins/plugins/github/GitHubUtils.java
@@ -3,50 +3,51 @@ package io.jenkins.plugins.github;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
 public class GitHubUtils {
-  public static GitHub loginToGithub(GitHubParameters parameters, TaskListener listener) throws IOException, InterruptedException {
-    if (null == parameters.getCredentialId()) {
-      throw new IllegalArgumentException("credentialId cannot be null.");
+    public static GitHub loginToGithub(GitHubParameters parameters, TaskListener listener)
+            throws IOException, InterruptedException {
+        if (null == parameters.getCredentialId()) {
+            throw new IllegalArgumentException("credentialId cannot be null.");
+        }
+
+        List<StringCredentials> credentialList = CredentialsProvider.lookupCredentials(
+                StringCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList());
+        Optional<StringCredentials> credentials = credentialList.stream()
+                .filter(p -> parameters.getCredentialId().equals(p.getId()))
+                .findFirst();
+
+        if (credentials.isEmpty()) {
+            throw new IllegalArgumentException(
+                    String.format("credentialId '%s' was not found", parameters.getCredentialId()));
+        }
+
+        GitHub gitHub;
+
+        if (null != parameters.getGithubServer()) {
+            listener.getLogger().printf("Connecting to %s", parameters.getGithubServer());
+            listener.getLogger().println();
+            gitHub = GitHub.connectUsingOAuth(
+                    parameters.getGithubServer(), credentials.get().getSecret().getPlainText());
+        } else {
+            gitHub = GitHub.connectUsingOAuth(credentials.get().getSecret().getPlainText());
+        }
+
+        return gitHub;
     }
 
-    List<StringCredentials> credentialList = CredentialsProvider.lookupCredentials(StringCredentials.class, Jenkins.get(), ACL.SYSTEM, Collections.emptyList());
-    Optional<StringCredentials> credentials = credentialList.stream().filter(p -> parameters.getCredentialId().equals(p.getId())).findFirst();
-
-    if (credentials.isEmpty()) {
-      throw new IllegalArgumentException(
-          String.format("credentialId '%s' was not found", parameters.getCredentialId())
-      );
+    public static GHRepository getRepository(GitHub gitHub, RepositoryParameters parameters) throws IOException {
+        if (null == parameters.getRepository()) {
+            throw new IllegalArgumentException("repository must be set.");
+        }
+        return gitHub.getRepository(parameters.getRepository());
     }
-
-    GitHub gitHub;
-
-    if (null != parameters.getGithubServer()) {
-      listener.getLogger().printf("Connecting to %s", parameters.getGithubServer());
-      listener.getLogger().println();
-      gitHub = GitHub.connectUsingOAuth(parameters.getGithubServer(), credentials.get().getSecret().getPlainText());
-    } else {
-      gitHub = GitHub.connectUsingOAuth(credentials.get().getSecret().getPlainText());
-    }
-
-    return gitHub;
-  }
-
-  public static GHRepository getRepository(GitHub gitHub, RepositoryParameters parameters) throws IOException {
-    if (null == parameters.getRepository()) {
-      throw new IllegalArgumentException(
-          "repository must be set."
-      );
-    }
-    return gitHub.getRepository(parameters.getRepository());
-  }
 }

--- a/src/main/java/io/jenkins/plugins/github/ParameterUtils.java
+++ b/src/main/java/io/jenkins/plugins/github/ParameterUtils.java
@@ -1,11 +1,9 @@
 package io.jenkins.plugins.github;
 
 public class ParameterUtils {
-  public static void checkArgument(String name, Object value) {
-    if (null == value) {
-      throw new IllegalArgumentException(
-          String.format("'%s' must be set", name)
-      );
+    public static void checkArgument(String name, Object value) {
+        if (null == value) {
+            throw new IllegalArgumentException(String.format("'%s' must be set", name));
+        }
     }
-  }
 }

--- a/src/main/java/io/jenkins/plugins/github/RepositoryParameters.java
+++ b/src/main/java/io/jenkins/plugins/github/RepositoryParameters.java
@@ -1,7 +1,7 @@
 package io.jenkins.plugins.github;
 
 public interface RepositoryParameters {
-  String getRepository();
-  void setRepository(String repository);
+    String getRepository();
 
+    void setRepository(String repository);
 }

--- a/src/main/java/io/jenkins/plugins/github/release/AbstractReleaseComparator.java
+++ b/src/main/java/io/jenkins/plugins/github/release/AbstractReleaseComparator.java
@@ -3,12 +3,12 @@ package io.jenkins.plugins.github.release;
 import java.util.Comparator;
 
 abstract class AbstractReleaseComparator implements Comparator<Release> {
-  boolean ascending = true;
+    boolean ascending = true;
 
-  abstract protected int doCompare(Release o1, Release o2);
+    protected abstract int doCompare(Release o1, Release o2);
 
-  @Override
-  public int compare(Release o1, Release o2) {
-    return doCompare(o1, o2) * (ascending ? 1 : -1);
-  }
+    @Override
+    public int compare(Release o1, Release o2) {
+        return doCompare(o1, o2) * (ascending ? 1 : -1);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/AbstractReleaseDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/github/release/AbstractReleaseDescriptor.java
@@ -11,18 +11,14 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 public abstract class AbstractReleaseDescriptor extends StepDescriptor {
-  @RequirePOST
-  public ListBoxModel doFillCredentialIdItems(@AncestorInPath Item context) {
+    @RequirePOST
+    public ListBoxModel doFillCredentialIdItems(@AncestorInPath Item context) {
 
+        if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+                || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
+            return new StandardListBoxModel();
+        }
 
-    if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) ||
-        context != null && !context.hasPermission(Item.EXTENDED_READ)) {
-      return new StandardListBoxModel();
+        return new StandardListBoxModel().includeEmptyValue().includeAs(ACL.SYSTEM, context, StringCredentials.class);
     }
-
-    return new StandardListBoxModel()
-        .includeEmptyValue()
-        .includeAs(ACL.SYSTEM, context, StringCredentials.class);
-  }
-
 }

--- a/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStep.java
+++ b/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStep.java
@@ -21,18 +21,18 @@ import java.util.Set;
 
 public class CreateReleaseStep extends Step implements Serializable, GitHubParameters, RepositoryParameters {
 
-  public String tag;
-  public String bodyText;
-  public String bodyFile;
-  public String commitish;
-  public Boolean draft;
-  public String name;
-  public Boolean prerelease;
-  public String categoryName;
-  public Boolean generateReleaseNotes;
-  public String credentialId;
-  public String gitHubServer;
-  public String repository;
+  String tag;
+  String bodyText;
+  String bodyFile;
+  String commitish;
+  Boolean draft;
+  String name;
+  Boolean prerelease;
+  String categoryName;
+  Boolean generateReleaseNotes;
+  String credentialId;
+  String gitHubServer;
+  String repository;
 
   @DataBoundConstructor
   public CreateReleaseStep() {

--- a/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStep.java
+++ b/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStep.java
@@ -9,135 +9,130 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.github.GitHubParameters;
 import io.jenkins.plugins.github.RepositoryParameters;
+import java.io.Serializable;
+import java.util.Set;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
-import java.util.Set;
-
-
 public class CreateReleaseStep extends Step implements Serializable, GitHubParameters, RepositoryParameters {
 
-  String tag;
-  String bodyText;
-  String bodyFile;
-  String commitish;
-  Boolean draft;
-  String name;
-  Boolean prerelease;
-  String categoryName;
-  Boolean generateReleaseNotes;
-  String credentialId;
-  String gitHubServer;
-  String repository;
+    String tag;
+    String bodyText;
+    String bodyFile;
+    String commitish;
+    Boolean draft;
+    String name;
+    Boolean prerelease;
+    String categoryName;
+    Boolean generateReleaseNotes;
+    String credentialId;
+    String gitHubServer;
+    String repository;
 
-  @DataBoundConstructor
-  public CreateReleaseStep() {
+    @DataBoundConstructor
+    public CreateReleaseStep() {}
 
-  }
-
-  public StepExecution start(StepContext context) throws Exception {
-    return new CreateReleaseStepExecution(this, context);
-  }
-
-  @Override
-  public String getCredentialId() {
-    return this.credentialId;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setCredentialId(String credentialId) {
-    this.credentialId = Util.fixEmptyAndTrim(credentialId);
-  }
-
-  @Override
-  public String getGithubServer() {
-    return this.gitHubServer;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setGithubServer(String gitHubServer) {
-    this.gitHubServer = Util.fixEmptyAndTrim(gitHubServer);
-  }
-
-  @Override
-  public String getRepository() {
-    return this.repository;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setRepository(String repository) {
-    this.repository = Util.fixEmptyAndTrim(repository);
-  }
-
-  @DataBoundSetter
-  public void setTag(String tag) {
-    this.tag = Util.fixEmptyAndTrim(tag);
-  }
-
-  @DataBoundSetter
-  public void setBodyText(String bodyText) {
-    this.bodyText = Util.fixEmptyAndTrim(bodyText);
-  }
-
-  @DataBoundSetter
-  public void setBodyFile(String bodyFile) {
-    this.bodyFile = Util.fixEmptyAndTrim(bodyFile);
-  }
-
-  @DataBoundSetter
-  public void setCommitish(String commitish) {
-    this.commitish = Util.fixEmptyAndTrim(commitish);
-  }
-
-  @DataBoundSetter
-  public void setDraft(Boolean draft) {
-    this.draft = draft;
-  }
-
-  @DataBoundSetter
-  public void setName(String name) {
-    this.name = Util.fixEmptyAndTrim(name);
-  }
-
-  @DataBoundSetter
-  public void setPrerelease(Boolean prerelease) {
-    this.prerelease = prerelease;
-  }
-
-  @DataBoundSetter
-  public void setCategoryName(String categoryName) {
-    this.categoryName = Util.fixEmptyAndTrim(categoryName);
-  }
-
-  @DataBoundSetter
-  public void setGenerateReleaseNotes(Boolean generateReleaseNotes) {
-    this.generateReleaseNotes = generateReleaseNotes;
-  }
-
-  @Extension
-  public static class DescriptorImpl extends AbstractReleaseDescriptor {
-    @Override
-    public Set<? extends Class<?>> getRequiredContext() {
-      return ImmutableSet.of(Run.class, TaskListener.class, FilePath.class);
+    public StepExecution start(StepContext context) throws Exception {
+        return new CreateReleaseStepExecution(this, context);
     }
 
     @Override
-    public String getFunctionName() {
-      return "createGitHubRelease";
+    public String getCredentialId() {
+        return this.credentialId;
     }
 
-    @NonNull
+    @DataBoundSetter
     @Override
-    public String getDisplayName() {
-      return "createGitHubRelease";
+    public void setCredentialId(String credentialId) {
+        this.credentialId = Util.fixEmptyAndTrim(credentialId);
     }
-  }
 
+    @Override
+    public String getGithubServer() {
+        return this.gitHubServer;
+    }
+
+    @DataBoundSetter
+    @Override
+    public void setGithubServer(String gitHubServer) {
+        this.gitHubServer = Util.fixEmptyAndTrim(gitHubServer);
+    }
+
+    @Override
+    public String getRepository() {
+        return this.repository;
+    }
+
+    @DataBoundSetter
+    @Override
+    public void setRepository(String repository) {
+        this.repository = Util.fixEmptyAndTrim(repository);
+    }
+
+    @DataBoundSetter
+    public void setTag(String tag) {
+        this.tag = Util.fixEmptyAndTrim(tag);
+    }
+
+    @DataBoundSetter
+    public void setBodyText(String bodyText) {
+        this.bodyText = Util.fixEmptyAndTrim(bodyText);
+    }
+
+    @DataBoundSetter
+    public void setBodyFile(String bodyFile) {
+        this.bodyFile = Util.fixEmptyAndTrim(bodyFile);
+    }
+
+    @DataBoundSetter
+    public void setCommitish(String commitish) {
+        this.commitish = Util.fixEmptyAndTrim(commitish);
+    }
+
+    @DataBoundSetter
+    public void setDraft(Boolean draft) {
+        this.draft = draft;
+    }
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = Util.fixEmptyAndTrim(name);
+    }
+
+    @DataBoundSetter
+    public void setPrerelease(Boolean prerelease) {
+        this.prerelease = prerelease;
+    }
+
+    @DataBoundSetter
+    public void setCategoryName(String categoryName) {
+        this.categoryName = Util.fixEmptyAndTrim(categoryName);
+    }
+
+    @DataBoundSetter
+    public void setGenerateReleaseNotes(Boolean generateReleaseNotes) {
+        this.generateReleaseNotes = generateReleaseNotes;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractReleaseDescriptor {
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(Run.class, TaskListener.class, FilePath.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "createGitHubRelease";
+        }
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "createGitHubRelease";
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStep.java
+++ b/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStep.java
@@ -29,6 +29,7 @@ public class CreateReleaseStep extends Step implements Serializable, GitHubParam
   public String name;
   public Boolean prerelease;
   public String categoryName;
+  public Boolean generateReleaseNotes;
   public String credentialId;
   public String gitHubServer;
   public String repository;
@@ -113,6 +114,11 @@ public class CreateReleaseStep extends Step implements Serializable, GitHubParam
   @DataBoundSetter
   public void setCategoryName(String categoryName) {
     this.categoryName = Util.fixEmptyAndTrim(categoryName);
+  }
+
+  @DataBoundSetter
+  public void setGenerateReleaseNotes(Boolean generateReleaseNotes) {
+    this.generateReleaseNotes = generateReleaseNotes;
   }
 
   @Extension

--- a/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStepExecution.java
@@ -56,7 +56,7 @@ public class CreateReleaseStepExecution extends SynchronousStepExecution<Release
       ghReleaseBuilder = ghReleaseBuilder.body(body);
     }
     if (null != this.step.categoryName) {
-      ghReleaseBuilder = ghReleaseBuilder.body(this.step.categoryName);
+      ghReleaseBuilder = ghReleaseBuilder.categoryName(this.step.categoryName);
     }
     if (null != this.step.draft) {
       ghReleaseBuilder = ghReleaseBuilder.draft(this.step.draft);

--- a/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStepExecution.java
@@ -64,6 +64,9 @@ public class CreateReleaseStepExecution extends SynchronousStepExecution<Release
     if (null != this.step.prerelease) {
       ghReleaseBuilder = ghReleaseBuilder.prerelease(this.step.prerelease);
     }
+    if (null != this.step.generateReleaseNotes) {
+      ghReleaseBuilder = ghReleaseBuilder.generateReleaseNotes(this.step.generateReleaseNotes);
+    }
 
     GHRelease release = ghReleaseBuilder.create();
 

--- a/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/github/release/CreateReleaseStepExecution.java
@@ -12,64 +12,63 @@ import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
 public class CreateReleaseStepExecution extends SynchronousStepExecution<Release> {
-  private final CreateReleaseStep step;
+    private final CreateReleaseStep step;
 
-  protected CreateReleaseStepExecution(CreateReleaseStep step, StepContext context) {
-    super(context);
-    this.step = step;
-  }
-
-  @Override
-  protected Release run() throws Exception {
-    ParameterUtils.checkArgument("tag", this.step.tag);
-
-    if (null == this.step.commitish) {
-      throw new IllegalArgumentException(
-          "Could not determine commitish from build. 'commitish' parameter must be set."
-      );
+    protected CreateReleaseStepExecution(CreateReleaseStep step, StepContext context) {
+        super(context);
+        this.step = step;
     }
 
-    TaskListener listener = getContext().get(TaskListener.class);
-    FilePath filePath = getContext().get(FilePath.class);
-    GitHub gitHub = GitHubUtils.loginToGithub(this.step, listener);
-    GHRepository repository = GitHubUtils.getRepository(gitHub, this.step);
+    @Override
+    protected Release run() throws Exception {
+        ParameterUtils.checkArgument("tag", this.step.tag);
 
-    String body;
-    if (null != this.step.bodyText) {
-      body = this.step.bodyText;
-    } else if (null != this.step.bodyFile) {
-      FilePath bodyFile = filePath.child(this.step.bodyFile);
-      listener.getLogger().printf("Reading from %s.%n", bodyFile);
-      body = bodyFile.readToString();
-    } else {
-      body = null;
-    }
+        if (null == this.step.commitish) {
+            throw new IllegalArgumentException(
+                    "Could not determine commitish from build. 'commitish' parameter must be set.");
+        }
 
-    GHReleaseBuilder ghReleaseBuilder = repository.createRelease(this.step.tag)
-        .commitish(this.step.commitish);
+        TaskListener listener = getContext().get(TaskListener.class);
+        FilePath filePath = getContext().get(FilePath.class);
+        GitHub gitHub = GitHubUtils.loginToGithub(this.step, listener);
+        GHRepository repository = GitHubUtils.getRepository(gitHub, this.step);
 
-    if(null != this.step.name) {
-      ghReleaseBuilder = ghReleaseBuilder.name(this.step.name);
-    }
+        String body;
+        if (null != this.step.bodyText) {
+            body = this.step.bodyText;
+        } else if (null != this.step.bodyFile) {
+            FilePath bodyFile = filePath.child(this.step.bodyFile);
+            listener.getLogger().printf("Reading from %s.%n", bodyFile);
+            body = bodyFile.readToString();
+        } else {
+            body = null;
+        }
 
-    if (null != body) {
-      ghReleaseBuilder = ghReleaseBuilder.body(body);
-    }
-    if (null != this.step.categoryName) {
-      ghReleaseBuilder = ghReleaseBuilder.categoryName(this.step.categoryName);
-    }
-    if (null != this.step.draft) {
-      ghReleaseBuilder = ghReleaseBuilder.draft(this.step.draft);
-    }
-    if (null != this.step.prerelease) {
-      ghReleaseBuilder = ghReleaseBuilder.prerelease(this.step.prerelease);
-    }
-    if (null != this.step.generateReleaseNotes) {
-      ghReleaseBuilder = ghReleaseBuilder.generateReleaseNotes(this.step.generateReleaseNotes);
-    }
+        GHReleaseBuilder ghReleaseBuilder =
+                repository.createRelease(this.step.tag).commitish(this.step.commitish);
 
-    GHRelease release = ghReleaseBuilder.create();
+        if (null != this.step.name) {
+            ghReleaseBuilder = ghReleaseBuilder.name(this.step.name);
+        }
 
-    return Release.from(release);
-  }
+        if (null != body) {
+            ghReleaseBuilder = ghReleaseBuilder.body(body);
+        }
+        if (null != this.step.categoryName) {
+            ghReleaseBuilder = ghReleaseBuilder.categoryName(this.step.categoryName);
+        }
+        if (null != this.step.draft) {
+            ghReleaseBuilder = ghReleaseBuilder.draft(this.step.draft);
+        }
+        if (null != this.step.prerelease) {
+            ghReleaseBuilder = ghReleaseBuilder.prerelease(this.step.prerelease);
+        }
+        if (null != this.step.generateReleaseNotes) {
+            ghReleaseBuilder = ghReleaseBuilder.generateReleaseNotes(this.step.generateReleaseNotes);
+        }
+
+        GHRelease release = ghReleaseBuilder.create();
+
+        return Release.from(release);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/ListReleaseStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/github/release/ListReleaseStepExecution.java
@@ -2,12 +2,6 @@ package io.jenkins.plugins.github.release;
 
 import hudson.model.TaskListener;
 import io.jenkins.plugins.github.GitHubUtils;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
-import org.kohsuke.github.GHRelease;
-import org.kohsuke.github.GHRepository;
-import org.kohsuke.github.GitHub;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -15,66 +9,72 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.github.GHRelease;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
 
 public class ListReleaseStepExecution extends SynchronousNonBlockingStepExecution<List<Release>> {
-  final ListReleasesStep step;
+    final ListReleasesStep step;
 
-  protected ListReleaseStepExecution(ListReleasesStep step, StepContext context) {
-    super(context);
-    this.step = step;
-  }
-
-  AbstractReleaseComparator findReleaseComparator(String name) {
-    String lower = name.toLowerCase();
-
-    AbstractReleaseComparator result;
-
-    switch (lower) {
-      case "symantecversion":
-        result = new SymantecVersionReleaseComparator();
-        break;
-      default:
-        throw new IllegalArgumentException(String.format("Invalid sort by '%s'. Valid options are 'SymantecVersion'", name));
-    }
-    return result;
-  }
-
-  @Override
-  protected List<Release> run() throws Exception {
-    TaskListener taskListener = this.getContext().get(TaskListener.class);
-    GitHub gitHub = GitHubUtils.loginToGithub(this.step, taskListener);
-    GHRepository repository = GitHubUtils.getRepository(gitHub, this.step);
-
-    List<GHRelease> allReleases = repository.listReleases().toList();
-    List<Predicate<GHRelease>> filters = new ArrayList<>();
-
-    if (null != this.step.tagNamePattern) {
-      final Pattern pattern = Pattern.compile(this.step.tagNamePattern);
-      filters.add(release -> {
-        Matcher matcher = pattern.matcher(release.getTagName());
-        return matcher.find();
-      });
+    protected ListReleaseStepExecution(ListReleasesStep step, StepContext context) {
+        super(context);
+        this.step = step;
     }
 
-    if (null != this.step.includeDrafts) {
-      filters.add(release -> this.step.includeDrafts == release.isDraft());
+    AbstractReleaseComparator findReleaseComparator(String name) {
+        String lower = name.toLowerCase();
+
+        AbstractReleaseComparator result;
+
+        switch (lower) {
+            case "symantecversion":
+                result = new SymantecVersionReleaseComparator();
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Invalid sort by '%s'. Valid options are 'SymantecVersion'", name));
+        }
+        return result;
     }
 
-    Stream<GHRelease> stream = allReleases.stream();
+    @Override
+    protected List<Release> run() throws Exception {
+        TaskListener taskListener = this.getContext().get(TaskListener.class);
+        GitHub gitHub = GitHubUtils.loginToGithub(this.step, taskListener);
+        GHRepository repository = GitHubUtils.getRepository(gitHub, this.step);
 
-    for (Predicate<GHRelease> filter : filters) {
-      stream = stream.filter(filter);
+        List<GHRelease> allReleases = repository.listReleases().toList();
+        List<Predicate<GHRelease>> filters = new ArrayList<>();
+
+        if (null != this.step.tagNamePattern) {
+            final Pattern pattern = Pattern.compile(this.step.tagNamePattern);
+            filters.add(release -> {
+                Matcher matcher = pattern.matcher(release.getTagName());
+                return matcher.find();
+            });
+        }
+
+        if (null != this.step.includeDrafts) {
+            filters.add(release -> this.step.includeDrafts == release.isDraft());
+        }
+
+        Stream<GHRelease> stream = allReleases.stream();
+
+        for (Predicate<GHRelease> filter : filters) {
+            stream = stream.filter(filter);
+        }
+
+        Stream<Release> converted = stream.map(Release::from);
+
+        if (null != this.step.sortBy) {
+            AbstractReleaseComparator comparator = findReleaseComparator(this.step.sortBy);
+            comparator.ascending = this.step.sortAscending;
+            converted = converted.sorted(comparator);
+        }
+
+        List<Release> result = converted.collect(Collectors.toList());
+        return result;
     }
-
-    Stream<Release> converted = stream.map(Release::from);
-
-    if (null != this.step.sortBy) {
-      AbstractReleaseComparator comparator = findReleaseComparator(this.step.sortBy);
-      comparator.ascending = this.step.sortAscending;
-      converted = converted.sorted(comparator);
-    }
-
-    List<Release> result = converted.collect(Collectors.toList());
-    return result;
-  }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/ListReleasesStep.java
+++ b/src/main/java/io/jenkins/plugins/github/release/ListReleasesStep.java
@@ -11,8 +11,10 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.github.GitHubParameters;
-import jenkins.model.Jenkins;
 import io.jenkins.plugins.github.RepositoryParameters;
+import java.io.Serializable;
+import java.util.Set;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -21,112 +23,102 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import java.io.Serializable;
-import java.util.Set;
-
 public class ListReleasesStep extends Step implements Serializable, GitHubParameters, RepositoryParameters {
 
-  String tagNamePattern;
-  Boolean includeDrafts;
-  String sortBy;
-  Boolean sortAscending = true;
-  String credentialId;
-  String githubServer;
-  String repository;
+    String tagNamePattern;
+    Boolean includeDrafts;
+    String sortBy;
+    Boolean sortAscending = true;
+    String credentialId;
+    String githubServer;
+    String repository;
 
-  @DataBoundConstructor
-  public ListReleasesStep() {
+    @DataBoundConstructor
+    public ListReleasesStep() {}
 
-  }
+    @DataBoundSetter
+    public void setTagNamePattern(String tagNamePattern) {
+        this.tagNamePattern = Util.fixEmptyAndTrim(tagNamePattern);
+    }
 
-  @DataBoundSetter
-  public void setTagNamePattern(String tagNamePattern) {
-    this.tagNamePattern = Util.fixEmptyAndTrim(tagNamePattern);
-  }
+    @DataBoundSetter
+    public void setIncludeDrafts(Boolean includeDrafts) {
+        this.includeDrafts = includeDrafts;
+    }
 
-  @DataBoundSetter
-  public void setIncludeDrafts(Boolean includeDrafts) {
-    this.includeDrafts = includeDrafts;
-  }
+    public StepExecution start(StepContext context) throws Exception {
+        return new ListReleaseStepExecution(this, context);
+    }
 
-  public StepExecution start(StepContext context) throws Exception {
-    return new ListReleaseStepExecution(this, context);
-  }
+    @DataBoundSetter
+    public void setSortBy(String sortBy) {
+        this.sortBy = Util.fixEmptyAndTrim(sortBy);
+    }
 
-  @DataBoundSetter
-  public void setSortBy(String sortBy) {
-    this.sortBy = Util.fixEmptyAndTrim(sortBy);
-  }
-
-  @DataBoundSetter
-  public void setSortAscending(Boolean sortAscending) {
-    this.sortAscending = sortAscending;
-  }
-
-  @Override
-  public String getCredentialId() {
-    return this.credentialId;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setCredentialId(String credentialId) {
-    this.credentialId = Util.fixEmptyAndTrim(credentialId);
-  }
-
-  @Override
-  public String getGithubServer() {
-    return this.githubServer;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setGithubServer(String gitHubServer) {
-    this.githubServer = Util.fixEmptyAndTrim(gitHubServer);
-  }
-
-
-  @Override
-  public String getRepository() {
-    return this.repository;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setRepository(String repository) {
-    this.repository = Util.fixEmptyAndTrim(repository);
-  }
-
-
-  @Extension
-  public static class DescriptorImpl extends AbstractReleaseDescriptor {
-    @Override
-    public Set<? extends Class<?>> getRequiredContext() {
-      return ImmutableSet.of(Run.class, TaskListener.class, FilePath.class);
+    @DataBoundSetter
+    public void setSortAscending(Boolean sortAscending) {
+        this.sortAscending = sortAscending;
     }
 
     @Override
-    public String getFunctionName() {
-      return "listGitHubReleases";
+    public String getCredentialId() {
+        return this.credentialId;
     }
 
-    @NonNull
+    @DataBoundSetter
     @Override
-    public String getDisplayName() {
-      return "listGitHubReleases";
+    public void setCredentialId(String credentialId) {
+        this.credentialId = Util.fixEmptyAndTrim(credentialId);
     }
 
-    @RequirePOST
-    public ListBoxModel doFillSortByItems(@AncestorInPath Item context) {
-      if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) ||
-          context != null && !context.hasPermission(Item.EXTENDED_READ)) {
-        return new StandardListBoxModel();
-      }
-
-      return new StandardListBoxModel()
-          .includeEmptyValue()
-          .add("SymantecVersion");
+    @Override
+    public String getGithubServer() {
+        return this.githubServer;
     }
-  }
 
+    @DataBoundSetter
+    @Override
+    public void setGithubServer(String gitHubServer) {
+        this.githubServer = Util.fixEmptyAndTrim(gitHubServer);
+    }
+
+    @Override
+    public String getRepository() {
+        return this.repository;
+    }
+
+    @DataBoundSetter
+    @Override
+    public void setRepository(String repository) {
+        this.repository = Util.fixEmptyAndTrim(repository);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractReleaseDescriptor {
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(Run.class, TaskListener.class, FilePath.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "listGitHubReleases";
+        }
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "listGitHubReleases";
+        }
+
+        @RequirePOST
+        public ListBoxModel doFillSortByItems(@AncestorInPath Item context) {
+            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+                    || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
+                return new StandardListBoxModel();
+            }
+
+            return new StandardListBoxModel().includeEmptyValue().add("SymantecVersion");
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/ListReleasesStep.java
+++ b/src/main/java/io/jenkins/plugins/github/release/ListReleasesStep.java
@@ -26,10 +26,10 @@ import java.util.Set;
 
 public class ListReleasesStep extends Step implements Serializable, GitHubParameters, RepositoryParameters {
 
-  public String tagNamePattern;
-  public Boolean includeDrafts;
-  public String sortBy;
-  public Boolean sortAscending = true;
+  String tagNamePattern;
+  Boolean includeDrafts;
+  String sortBy;
+  Boolean sortAscending = true;
   String credentialId;
   String githubServer;
   String repository;

--- a/src/main/java/io/jenkins/plugins/github/release/Release.java
+++ b/src/main/java/io/jenkins/plugins/github/release/Release.java
@@ -1,113 +1,132 @@
 package io.jenkins.plugins.github.release;
 
+import java.io.Serializable;
+import java.util.StringJoiner;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.github.GHRelease;
 
-import java.io.Serializable;
-import java.util.StringJoiner;
-
 public class Release implements Serializable {
-  @Whitelisted
-  public final long id;
-  @Whitelisted
-  public final String htmlUrl;
-  @Whitelisted
-  public final String assetsUrl;
-  @Whitelisted
-  public final String uploadUrl;
-  @Whitelisted
-  public final String tagName;
-  @Whitelisted
-  public final String targetCommitish;
-  @Whitelisted
-  public final String name;
-  @Whitelisted
-  public final String body;
-  @Whitelisted
-  public final boolean draft;
-  @Whitelisted
-  public final boolean prerelease;
-  @Whitelisted
-  public final String tarballUrl;
-  @Whitelisted
-  public final String zipballUrl;
-  @Whitelisted
-  public final String discussionUrl;
+    @Whitelisted
+    public final long id;
 
-  public Release(long id, String htmlUrl, String assetsUrl, String uploadUrl, String tagName, String targetCommitish, String name, String body, boolean draft, boolean prerelease, String tarballUrl, String zipballUrl, String discussionUrl) {
-    this.id = id;
-    this.htmlUrl = htmlUrl;
-    this.assetsUrl = assetsUrl;
-    this.uploadUrl = uploadUrl;
-    this.tagName = tagName;
-    this.targetCommitish = targetCommitish;
-    this.name = name;
-    this.body = body;
-    this.draft = draft;
-    this.prerelease = prerelease;
-    this.tarballUrl = tarballUrl;
-    this.zipballUrl = zipballUrl;
-    this.discussionUrl = discussionUrl;
-  }
+    @Whitelisted
+    public final String htmlUrl;
 
-  Release(String tagName) {
-    this(1234, null, null, null, tagName, null, null, null, false, false, null, null, null);
-  }
+    @Whitelisted
+    public final String assetsUrl;
 
+    @Whitelisted
+    public final String uploadUrl;
 
-  static Release from(GHRelease release) {
-    Release result = new Release(
-        release.getId(),
-        (null != release.getHtmlUrl() ? release.getHtmlUrl().toString() : null),
-        release.getAssetsUrl(),
-        release.getUploadUrl(),
-        release.getTagName(),
-        release.getTargetCommitish(),
-        release.getName(),
-        release.getBody(),
-        release.isDraft(),
-        release.isPrerelease(),
-        release.getTarballUrl(),
-        release.getZipballUrl(),
-        release.getDiscussionUrl()
-    );
+    @Whitelisted
+    public final String tagName;
 
-    return result;
-  }
+    @Whitelisted
+    public final String targetCommitish;
 
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", Release.class.getSimpleName() + "[", "]")
-        .add("id=" + id)
-        .add("htmlUrl='" + htmlUrl + "'")
-        .add("assetsUrl='" + assetsUrl + "'")
-        .add("uploadUrl='" + uploadUrl + "'")
-        .add("tagName='" + tagName + "'")
-        .add("targetCommitish='" + targetCommitish + "'")
-        .add("name='" + name + "'")
-        .add("body='" + body + "'")
-        .add("draft=" + draft)
-        .add("prerelease=" + prerelease)
-        .add("tarballUrl='" + tarballUrl + "'")
-        .add("zipballUrl='" + zipballUrl + "'")
-        .add("discussionUrl='" + discussionUrl + "'")
-        .toString();
-  }
+    @Whitelisted
+    public final String name;
 
+    @Whitelisted
+    public final String body;
 
-  private SymantecVersion symantecVersion() {
-    if (!SymantecVersion.isSymantecVersion(this.tagName)) {
-      throw new IllegalStateException(
-          String.format("TagName '%s' is not a symantec version.", this.tagName)
-      );
+    @Whitelisted
+    public final boolean draft;
+
+    @Whitelisted
+    public final boolean prerelease;
+
+    @Whitelisted
+    public final String tarballUrl;
+
+    @Whitelisted
+    public final String zipballUrl;
+
+    @Whitelisted
+    public final String discussionUrl;
+
+    public Release(
+            long id,
+            String htmlUrl,
+            String assetsUrl,
+            String uploadUrl,
+            String tagName,
+            String targetCommitish,
+            String name,
+            String body,
+            boolean draft,
+            boolean prerelease,
+            String tarballUrl,
+            String zipballUrl,
+            String discussionUrl) {
+        this.id = id;
+        this.htmlUrl = htmlUrl;
+        this.assetsUrl = assetsUrl;
+        this.uploadUrl = uploadUrl;
+        this.tagName = tagName;
+        this.targetCommitish = targetCommitish;
+        this.name = name;
+        this.body = body;
+        this.draft = draft;
+        this.prerelease = prerelease;
+        this.tarballUrl = tarballUrl;
+        this.zipballUrl = zipballUrl;
+        this.discussionUrl = discussionUrl;
     }
-    return SymantecVersion.of(this.tagName);
-  }
 
-  @Whitelisted
-  public String nextSymantecRevision() {
-    SymantecVersion thisVersion = symantecVersion();
-    SymantecVersion nextVersion = thisVersion.incrementRevision();
-    return nextVersion.toString();
-  }
+    Release(String tagName) {
+        this(1234, null, null, null, tagName, null, null, null, false, false, null, null, null);
+    }
+
+    static Release from(GHRelease release) {
+        Release result = new Release(
+                release.getId(),
+                (null != release.getHtmlUrl() ? release.getHtmlUrl().toString() : null),
+                release.getAssetsUrl(),
+                release.getUploadUrl(),
+                release.getTagName(),
+                release.getTargetCommitish(),
+                release.getName(),
+                release.getBody(),
+                release.isDraft(),
+                release.isPrerelease(),
+                release.getTarballUrl(),
+                release.getZipballUrl(),
+                release.getDiscussionUrl());
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", Release.class.getSimpleName() + "[", "]")
+                .add("id=" + id)
+                .add("htmlUrl='" + htmlUrl + "'")
+                .add("assetsUrl='" + assetsUrl + "'")
+                .add("uploadUrl='" + uploadUrl + "'")
+                .add("tagName='" + tagName + "'")
+                .add("targetCommitish='" + targetCommitish + "'")
+                .add("name='" + name + "'")
+                .add("body='" + body + "'")
+                .add("draft=" + draft)
+                .add("prerelease=" + prerelease)
+                .add("tarballUrl='" + tarballUrl + "'")
+                .add("zipballUrl='" + zipballUrl + "'")
+                .add("discussionUrl='" + discussionUrl + "'")
+                .toString();
+    }
+
+    private SymantecVersion symantecVersion() {
+        if (!SymantecVersion.isSymantecVersion(this.tagName)) {
+            throw new IllegalStateException(String.format("TagName '%s' is not a symantec version.", this.tagName));
+        }
+        return SymantecVersion.of(this.tagName);
+    }
+
+    @Whitelisted
+    public String nextSymantecRevision() {
+        SymantecVersion thisVersion = symantecVersion();
+        SymantecVersion nextVersion = thisVersion.incrementRevision();
+        return nextVersion.toString();
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/SymantecVersion.java
+++ b/src/main/java/io/jenkins/plugins/github/release/SymantecVersion.java
@@ -6,100 +6,79 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class SymantecVersion implements Comparable<SymantecVersion>, Serializable {
-  public final int major;
-  public final int minor;
-  public final int revision;
+    public final int major;
+    public final int minor;
+    public final int revision;
 
-  SymantecVersion(int major, int minor, int revision) {
-    this.major = major;
-    this.minor = minor;
-    this.revision = revision;
-  }
-
-  @Override
-  public int compareTo(SymantecVersion that) {
-    return
-        (Integer.compare(this.major, that.major) * 100) +
-            (Integer.compare(this.minor, that.minor) * 10) +
-            (Integer.compare(this.revision, that.revision));
-  }
-
-  private static final Pattern VERSION_PATTERN = Pattern.compile("^[vV]*(\\d+)\\.(\\d+)\\.(\\d+)$");
-
-  public static boolean isSymantecVersion(String version) {
-    if (null == version) {
-      return false;
+    SymantecVersion(int major, int minor, int revision) {
+        this.major = major;
+        this.minor = minor;
+        this.revision = revision;
     }
-    Matcher matcher = VERSION_PATTERN.matcher(version);
-    return matcher.matches();
-  }
 
-  public static SymantecVersion of(String version) {
-    if (null == version) {
-      throw new IllegalArgumentException("version cannot be null");
+    @Override
+    public int compareTo(SymantecVersion that) {
+        return (Integer.compare(this.major, that.major) * 100)
+                + (Integer.compare(this.minor, that.minor) * 10)
+                + (Integer.compare(this.revision, that.revision));
     }
-    Matcher matcher = VERSION_PATTERN.matcher(version);
-    if (!matcher.matches()) {
-      throw new IllegalArgumentException(
-          String.format(
-              "version '%s' does not match pattern '%s'",
-              version,
-              VERSION_PATTERN.pattern()
-          )
-      );
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^[vV]*(\\d+)\\.(\\d+)\\.(\\d+)$");
+
+    public static boolean isSymantecVersion(String version) {
+        if (null == version) {
+            return false;
+        }
+        Matcher matcher = VERSION_PATTERN.matcher(version);
+        return matcher.matches();
     }
-    int major = Integer.parseInt(matcher.group(1));
-    int minor = Integer.parseInt(matcher.group(2));
-    int revision = Integer.parseInt(matcher.group(3));
-    return new SymantecVersion(major, minor, revision);
-  }
 
-  @Override
-  public String toString() {
-    return String.format("%s.%s.%s", this.major, this.minor, this.revision);
-  }
-
-  public SymantecVersion incrementRevision() {
-    return new SymantecVersion(
-        this.major,
-        this.minor,
-        this.revision + 1
-    );
-  }
-
-  public SymantecVersion incrementMinor() {
-    return new SymantecVersion(
-        this.major,
-        this.minor + 1,
-        this.revision
-    );
-  }
-
-  public SymantecVersion incrementMajor() {
-    return new SymantecVersion(
-        this.major + 1,
-        this.minor,
-        this.revision
-    );
-  }
-
-
-  @Override
-  public boolean equals(Object obj) {
-    if (null == obj) {
-      return false;
+    public static SymantecVersion of(String version) {
+        if (null == version) {
+            throw new IllegalArgumentException("version cannot be null");
+        }
+        Matcher matcher = VERSION_PATTERN.matcher(version);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(
+                    String.format("version '%s' does not match pattern '%s'", version, VERSION_PATTERN.pattern()));
+        }
+        int major = Integer.parseInt(matcher.group(1));
+        int minor = Integer.parseInt(matcher.group(2));
+        int revision = Integer.parseInt(matcher.group(3));
+        return new SymantecVersion(major, minor, revision);
     }
-    if (!(obj instanceof SymantecVersion)) {
-      return false;
-    }
-    SymantecVersion that = (SymantecVersion) obj;
-    return (this.major == that.major) &&
-        (this.minor == that.minor) &&
-        (this.revision == that.revision);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(major, minor, revision);
-  }
+    @Override
+    public String toString() {
+        return String.format("%s.%s.%s", this.major, this.minor, this.revision);
+    }
+
+    public SymantecVersion incrementRevision() {
+        return new SymantecVersion(this.major, this.minor, this.revision + 1);
+    }
+
+    public SymantecVersion incrementMinor() {
+        return new SymantecVersion(this.major, this.minor + 1, this.revision);
+    }
+
+    public SymantecVersion incrementMajor() {
+        return new SymantecVersion(this.major + 1, this.minor, this.revision);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (null == obj) {
+            return false;
+        }
+        if (!(obj instanceof SymantecVersion)) {
+            return false;
+        }
+        SymantecVersion that = (SymantecVersion) obj;
+        return (this.major == that.major) && (this.minor == that.minor) && (this.revision == that.revision);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, revision);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/SymantecVersionReleaseComparator.java
+++ b/src/main/java/io/jenkins/plugins/github/release/SymantecVersionReleaseComparator.java
@@ -4,18 +4,18 @@ import java.io.Serializable;
 
 class SymantecVersionReleaseComparator extends AbstractReleaseComparator implements Serializable {
 
-  @Override
-  protected int doCompare(Release o1, Release o2) {
-    if (SymantecVersion.isSymantecVersion(o1.tagName) && !SymantecVersion.isSymantecVersion(o2.tagName)) {
-      return 1;
-    } else if (!SymantecVersion.isSymantecVersion(o1.tagName) && SymantecVersion.isSymantecVersion(o2.tagName)) {
-      return -1;
-    } else if (!SymantecVersion.isSymantecVersion(o1.tagName) && !SymantecVersion.isSymantecVersion(o2.tagName)) {
-      return 0;
-    }
+    @Override
+    protected int doCompare(Release o1, Release o2) {
+        if (SymantecVersion.isSymantecVersion(o1.tagName) && !SymantecVersion.isSymantecVersion(o2.tagName)) {
+            return 1;
+        } else if (!SymantecVersion.isSymantecVersion(o1.tagName) && SymantecVersion.isSymantecVersion(o2.tagName)) {
+            return -1;
+        } else if (!SymantecVersion.isSymantecVersion(o1.tagName) && !SymantecVersion.isSymantecVersion(o2.tagName)) {
+            return 0;
+        }
 
-    SymantecVersion v1 = SymantecVersion.of(o1.tagName);
-    SymantecVersion v2 = SymantecVersion.of(o2.tagName);
-    return v1.compareTo(v2);
-  }
+        SymantecVersion v1 = SymantecVersion.of(o1.tagName);
+        SymantecVersion v2 = SymantecVersion.of(o2.tagName);
+        return v1.compareTo(v2);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
 public class UploadAsset implements Serializable {
   static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
-  public String contentType = DEFAULT_CONTENT_TYPE;
+  String contentType = DEFAULT_CONTENT_TYPE;
 
   @DataBoundConstructor
   public UploadAsset(String filePath) {
@@ -26,7 +26,7 @@ public class UploadAsset implements Serializable {
     this.contentType = null == c ? DEFAULT_CONTENT_TYPE : c;
   }
 
-  public String filePath;
+  String filePath;
 
   @DataBoundSetter
   public void setFilePath(String filePath) {

--- a/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadAsset.java
@@ -2,49 +2,46 @@ package io.jenkins.plugins.github.release;
 
 import hudson.FilePath;
 import hudson.Util;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 public class UploadAsset implements Serializable {
-  static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+    static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
-  String contentType = DEFAULT_CONTENT_TYPE;
+    String contentType = DEFAULT_CONTENT_TYPE;
 
-  @DataBoundConstructor
-  public UploadAsset(String filePath) {
-    setFilePath(filePath);
-  }
-
-
-  @DataBoundSetter
-  public void setContentType(String contentType) {
-    String c = Util.fixEmptyAndTrim(contentType);
-    this.contentType = null == c ? DEFAULT_CONTENT_TYPE : c;
-  }
-
-  String filePath;
-
-  @DataBoundSetter
-  public void setFilePath(String filePath) {
-    this.filePath = Util.fixEmptyAndTrim(filePath);
-  }
-
-  public InputStream toStream(FilePath workspace) throws IOException, InterruptedException {
-    return workspace.child(filePath).read();
-  }
-
-
-  public boolean isMissing(FilePath workspace) {
-    try {
-      FilePath file = workspace.child(this.filePath);
-      return !file.exists() || file.isDirectory();
-    } catch (IOException | InterruptedException e) {
-      // If an exception occurs, assume the file is missing
-      return true;
+    @DataBoundConstructor
+    public UploadAsset(String filePath) {
+        setFilePath(filePath);
     }
-  }
+
+    @DataBoundSetter
+    public void setContentType(String contentType) {
+        String c = Util.fixEmptyAndTrim(contentType);
+        this.contentType = null == c ? DEFAULT_CONTENT_TYPE : c;
+    }
+
+    String filePath;
+
+    @DataBoundSetter
+    public void setFilePath(String filePath) {
+        this.filePath = Util.fixEmptyAndTrim(filePath);
+    }
+
+    public InputStream toStream(FilePath workspace) throws IOException, InterruptedException {
+        return workspace.child(filePath).read();
+    }
+
+    public boolean isMissing(FilePath workspace) {
+        try {
+            FilePath file = workspace.child(this.filePath);
+            return !file.exists() || file.isDirectory();
+        } catch (IOException | InterruptedException e) {
+            // If an exception occurs, assume the file is missing
+            return true;
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStep.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStep.java
@@ -21,11 +21,11 @@ import java.util.Set;
 
 public class UploadReleaseAssetStep extends Step implements Serializable, GitHubParameters, RepositoryParameters {
 
-  public String tagName;
-  public List<UploadAsset> uploadAssets;
-  public String credentialId;
-  public String githubServer;
-  public String repository;
+  String tagName;
+  List<UploadAsset> uploadAssets;
+  String credentialId;
+  String githubServer;
+  String repository;
 
   @DataBoundConstructor
   public UploadReleaseAssetStep(String tagName) {

--- a/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStep.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStep.java
@@ -9,92 +9,91 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.github.GitHubParameters;
 import io.jenkins.plugins.github.RepositoryParameters;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Set;
-
 public class UploadReleaseAssetStep extends Step implements Serializable, GitHubParameters, RepositoryParameters {
 
-  String tagName;
-  List<UploadAsset> uploadAssets;
-  String credentialId;
-  String githubServer;
-  String repository;
+    String tagName;
+    List<UploadAsset> uploadAssets;
+    String credentialId;
+    String githubServer;
+    String repository;
 
-  @DataBoundConstructor
-  public UploadReleaseAssetStep(String tagName) {
-    setTagName(tagName);
-  }
+    @DataBoundConstructor
+    public UploadReleaseAssetStep(String tagName) {
+        setTagName(tagName);
+    }
 
-  @DataBoundSetter
-  public void setTagName(String tagName) {
-    this.tagName = Util.fixEmptyAndTrim(tagName);
-  }
+    @DataBoundSetter
+    public void setTagName(String tagName) {
+        this.tagName = Util.fixEmptyAndTrim(tagName);
+    }
 
-  @DataBoundSetter
-  public void setUploadAssets(List<UploadAsset> uploadAssets) {
-    this.uploadAssets = uploadAssets;
-  }
-  @Override
-  public String getCredentialId() {
-    return this.credentialId;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setCredentialId(String credentialId) {
-    this.credentialId = Util.fixEmptyAndTrim(credentialId);
-  }
-
-  @Override
-  public String getGithubServer() {
-    return this.githubServer;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setGithubServer(String gitHubServer) {
-    this.githubServer = Util.fixEmptyAndTrim(gitHubServer);
-  }
-
-
-  @Override
-  public String getRepository() {
-    return this.repository;
-  }
-
-  @DataBoundSetter
-  @Override
-  public void setRepository(String repository) {
-    this.repository = Util.fixEmptyAndTrim(repository);
-  }
-
-  public StepExecution start(StepContext context) throws Exception {
-    return new UploadReleaseAssetStepExecution(this, context);
-  }
-
-  @Extension
-  public static class DescriptorImpl extends AbstractReleaseDescriptor {
-    @Override
-    public Set<? extends Class<?>> getRequiredContext() {
-      return ImmutableSet.of(Run.class, TaskListener.class, FilePath.class);
+    @DataBoundSetter
+    public void setUploadAssets(List<UploadAsset> uploadAssets) {
+        this.uploadAssets = uploadAssets;
     }
 
     @Override
-    public String getFunctionName() {
-      return "uploadGithubReleaseAsset";
+    public String getCredentialId() {
+        return this.credentialId;
     }
 
-    @NonNull
+    @DataBoundSetter
     @Override
-    public String getDisplayName() {
-      return "uploadGithubReleaseAsset";
+    public void setCredentialId(String credentialId) {
+        this.credentialId = Util.fixEmptyAndTrim(credentialId);
     }
-  }
+
+    @Override
+    public String getGithubServer() {
+        return this.githubServer;
+    }
+
+    @DataBoundSetter
+    @Override
+    public void setGithubServer(String gitHubServer) {
+        this.githubServer = Util.fixEmptyAndTrim(gitHubServer);
+    }
+
+    @Override
+    public String getRepository() {
+        return this.repository;
+    }
+
+    @DataBoundSetter
+    @Override
+    public void setRepository(String repository) {
+        this.repository = Util.fixEmptyAndTrim(repository);
+    }
+
+    public StepExecution start(StepContext context) throws Exception {
+        return new UploadReleaseAssetStepExecution(this, context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractReleaseDescriptor {
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(Run.class, TaskListener.class, FilePath.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "uploadGithubReleaseAsset";
+        }
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "uploadGithubReleaseAsset";
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/github/release/UploadReleaseAssetStepExecution.java
@@ -3,72 +3,58 @@ package io.jenkins.plugins.github.release;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.github.GitHubUtils;
+import java.io.File;
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
 import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
-import java.io.File;
-import java.io.InputStream;
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class UploadReleaseAssetStepExecution extends SynchronousStepExecution<Void> {
-  private final UploadReleaseAssetStep step;
+    private final UploadReleaseAssetStep step;
 
-  protected UploadReleaseAssetStepExecution(UploadReleaseAssetStep step, StepContext context) {
-    super(context);
-    this.step = step;
-  }
-
-  @Override
-  protected Void run() throws Exception {
-    // Get the workspace FilePath for the node
-    FilePath workspace = getContext().get(FilePath.class);
-    TaskListener taskListener = this.getContext().get(TaskListener.class);
-    GitHub gitHub = GitHubUtils.loginToGithub(this.step, taskListener);
-    GHRepository repository = GitHubUtils.getRepository(gitHub, this.step);
-    GHRelease release = repository.getReleaseByTagName(this.step.tagName);
-
-    if (this.step.uploadAssets == null || this.step.uploadAssets.isEmpty()) {
-      throw new IllegalStateException(
-          "uploadAssets cannot be null or empty."
-      );
+    protected UploadReleaseAssetStepExecution(UploadReleaseAssetStep step, StepContext context) {
+        super(context);
+        this.step = step;
     }
 
-    List<UploadAsset> missingUploads = this.step.uploadAssets
-        .stream()
-        .filter(uploadAsset -> uploadAsset.isMissing(workspace))
-        .collect(Collectors.toList());
+    @Override
+    protected Void run() throws Exception {
+        // Get the workspace FilePath for the node
+        FilePath workspace = getContext().get(FilePath.class);
+        TaskListener taskListener = this.getContext().get(TaskListener.class);
+        GitHub gitHub = GitHubUtils.loginToGithub(this.step, taskListener);
+        GHRepository repository = GitHubUtils.getRepository(gitHub, this.step);
+        GHRelease release = repository.getReleaseByTagName(this.step.tagName);
 
-    if (!missingUploads.isEmpty()) {
-      List<String> missingFilePaths = missingUploads
-          .stream()
-          .map(e -> e.filePath)
-          .collect(Collectors.toList());
+        if (this.step.uploadAssets == null || this.step.uploadAssets.isEmpty()) {
+            throw new IllegalStateException("uploadAssets cannot be null or empty.");
+        }
 
-      throw new IllegalStateException(
-          String.format(
-              "%s file(s) to upload were missing: %s",
-              missingFilePaths.size(),
-              String.join(", ", missingFilePaths)
-          )
-      );
+        List<UploadAsset> missingUploads = this.step.uploadAssets.stream()
+                .filter(uploadAsset -> uploadAsset.isMissing(workspace))
+                .collect(Collectors.toList());
+
+        if (!missingUploads.isEmpty()) {
+            List<String> missingFilePaths =
+                    missingUploads.stream().map(e -> e.filePath).collect(Collectors.toList());
+
+            throw new IllegalStateException(String.format(
+                    "%s file(s) to upload were missing: %s",
+                    missingFilePaths.size(), String.join(", ", missingFilePaths)));
+        }
+
+        for (UploadAsset uploadAsset : this.step.uploadAssets) {
+            taskListener.getLogger().printf("Started uploading %s%n", uploadAsset.filePath);
+            try (InputStream assetStream = uploadAsset.toStream(workspace)) {
+                release.uploadAsset(new File(uploadAsset.filePath).getName(), assetStream, uploadAsset.contentType);
+            }
+            taskListener.getLogger().printf("Finished uploading %s%n", uploadAsset.filePath);
+        }
+
+        return null;
     }
-
-    for (UploadAsset uploadAsset : this.step.uploadAssets) {
-      taskListener.getLogger().printf("Started uploading %s%n", uploadAsset.filePath);
-      try (InputStream assetStream = uploadAsset.toStream(workspace)) {
-        release.uploadAsset(
-            new File(uploadAsset.filePath).getName(),
-            assetStream,
-            uploadAsset.contentType
-        );
-      }
-      taskListener.getLogger().printf("Finished uploading %s%n", uploadAsset.filePath);
-    }
-
-    return null;
-  }
 }

--- a/src/main/resources/io/jenkins/plugins/github/release/CreateReleaseStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/github/release/CreateReleaseStep/config.jelly
@@ -19,7 +19,7 @@
         <f:textbox/>
     </f:entry>
 
-    <f:entry field="CreateReleaseStepTests.release.io.jenkins.plugins.github.bodyText" title="Text Representation of the release body.">
+    <f:entry field="bodyText" title="Text Representation of the release body.">
         <f:textarea/>
     </f:entry>
     <f:entry field="bodyFile" title="File to read with the release body">

--- a/src/main/resources/io/jenkins/plugins/github/release/CreateReleaseStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/github/release/CreateReleaseStep/config.jelly
@@ -37,4 +37,7 @@
     <f:entry field="categoryName" title="Category Name">
         <f:textbox/>
     </f:entry>
+    <f:entry field="generateReleaseNotes" title="Generate Release Notes">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/github/release/CreateReleaseStep/help-generateReleaseNotes.html
+++ b/src/main/resources/io/jenkins/plugins/github/release/CreateReleaseStep/help-generateReleaseNotes.html
@@ -1,0 +1,5 @@
+<div>
+    <p>Whether to automatically generate the release notes for this release. If set to <b>true</b>, GitHub will automatically generate the name and body for the release based on the merged pull requests since the last release.</p>
+    <p>If <b>bodyText</b> or <b>bodyFile</b> is also specified, that text will be prepended to the automatically generated notes.</p>
+    <p>Default: <b>false</b></p>
+</div>

--- a/src/test/java/io/jenkins/plugins/github/release/AbstractWireMockTests.java
+++ b/src/test/java/io/jenkins/plugins/github/release/AbstractWireMockTests.java
@@ -7,9 +7,6 @@ import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.junit.Rule;
-import org.jvnet.hudson.test.JenkinsRule;
-
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -17,76 +14,75 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public class AbstractWireMockTests {
-  protected final String baseFilesClassPath = this.getClass().getName().replace('.', '/');
-  ;
-  protected final String baseRecordPath = "src/test/resources/" + baseFilesClassPath;
+    protected final String baseFilesClassPath = this.getClass().getName().replace('.', '/');
+    ;
+    protected final String baseRecordPath = "src/test/resources/" + baseFilesClassPath;
 
-  protected String githubServer() {
-//    return "http://localhost:8080/";
-    return githubApi.baseUrl();
-  }
+    protected String githubServer() {
+        //    return "http://localhost:8080/";
+        return githubApi.baseUrl();
+    }
 
-  public WireMockRuleFactory factory = new WireMockRuleFactory();
-  @Rule
-  public WireMockRule githubApi = factory.getRule(WireMockConfiguration.options()
-          .dynamicPort()
-          .usingFilesUnderClasspath(baseFilesClassPath + "/api")
-          .extensions(
-              new ResponseTransformer() {
+    public WireMockRuleFactory factory = new WireMockRuleFactory();
+
+    @Rule
+    public WireMockRule githubApi = factory.getRule(WireMockConfiguration.options()
+            .dynamicPort()
+            .usingFilesUnderClasspath(baseFilesClassPath + "/api")
+            .extensions(new ResponseTransformer() {
                 @Override
-                public Response transform(Request request, Response response, FileSource files,
-                                          Parameters parameters) {
-                  try {
-                    if ("application/json"
-                        .equals(response.getHeaders().getContentTypeHeader().mimeTypePart())) {
-                      // Something strange happending here... turning off for now
-//                        return Response.Builder.like(response)
-//                            .but()
-//                            .body(response.getBodyAsString()
-//                                .replace("https://api.github.com/",
-//                                    "http://localhost:" + githubApi.port() + "/")
-//                                .replace("https://raw.githubusercontent.com/",
-//                                    "http://localhost:" + githubRaw.port() + "/")
-//                            )
-//                            .build();
+                public Response transform(Request request, Response response, FileSource files, Parameters parameters) {
+                    try {
+                        if ("application/json"
+                                .equals(response.getHeaders()
+                                        .getContentTypeHeader()
+                                        .mimeTypePart())) {
+                            // Something strange happending here... turning off for now
+                            //                        return Response.Builder.like(response)
+                            //                            .but()
+                            //                            .body(response.getBodyAsString()
+                            //                                .replace("https://api.github.com/",
+                            //                                    "http://localhost:" + githubApi.port() + "/")
+                            //                                .replace("https://raw.githubusercontent.com/",
+                            //                                    "http://localhost:" + githubRaw.port() + "/")
+                            //                            )
+                            //                            .build();
+                        }
+                    } catch (Exception e) {
                     }
-                  } catch (Exception e) {
-                  }
-                  return response;
+                    return response;
                 }
 
                 @Override
                 public String getName() {
-                  return "url-rewrite";
+                    return "url-rewrite";
                 }
+            }));
 
-              })
-  );
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
-  @Rule
-  public JenkinsRule j = new JenkinsRule();
+    protected String loadScript(String name) throws IOException {
 
-  protected String loadScript(String name) throws IOException {
+        String path = "/" + baseFilesClassPath + "/" + name;
 
-    String path = "/" + baseFilesClassPath + "/" + name;
+        String script;
+        try (InputStream inputStream = this.getClass().getResourceAsStream(path)) {
+            if (null == inputStream) {
+                throw new FileNotFoundException(path);
+            }
 
-    String script;
-    try (InputStream inputStream = this.getClass().getResourceAsStream(path)) {
-      if (null == inputStream) {
-        throw new FileNotFoundException(
-            path
-        );
-      }
-
-      try (Reader inputStreamReader = new InputStreamReader(inputStream)) {
-        try (BufferedReader reader = new BufferedReader(inputStreamReader)) {
-          script = reader.lines().collect(Collectors.joining("\n"));
+            try (Reader inputStreamReader = new InputStreamReader(inputStream)) {
+                try (BufferedReader reader = new BufferedReader(inputStreamReader)) {
+                    script = reader.lines().collect(Collectors.joining("\n"));
+                }
+            }
         }
-      }
-    }
 
-    return String.format(script, githubServer());
-  }
+        return String.format(script, githubServer());
+    }
 }

--- a/src/test/java/io/jenkins/plugins/github/release/CreateReleaseStepTests.java
+++ b/src/test/java/io/jenkins/plugins/github/release/CreateReleaseStepTests.java
@@ -83,4 +83,18 @@ public class CreateReleaseStepTests extends AbstractWireMockTests {
     job.setDefinition(new CpsFlowDefinition(script, true));
     j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
   }
+
+  @Test
+  public void executeGenerateReleaseNotes() throws Exception {
+    SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
+    instance.getCredentials().add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("asdfasd")));
+    instance.save();
+
+    final String script = loadScript("generateReleaseNotes.groovy");
+
+    WorkflowJob job = j.createProject(WorkflowJob.class);
+
+    job.setDefinition(new CpsFlowDefinition(script, true));
+    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+  }
 }

--- a/src/test/java/io/jenkins/plugins/github/release/CreateReleaseStepTests.java
+++ b/src/test/java/io/jenkins/plugins/github/release/CreateReleaseStepTests.java
@@ -36,65 +36,62 @@ import org.junit.Test;
 
 public class CreateReleaseStepTests extends AbstractWireMockTests {
 
+    @Test
+    public void missingCredentialId() throws Exception {
+        // Create a new Pipeline with the given (Scripted Pipeline) definition
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        String script = "" + "node {" + "  createGitHubRelease(tag: 'v1.2.3', commitish: '00000')" + "}";
 
-  @Test
-  public void missingCredentialId() throws Exception {
-    // Create a new Pipeline with the given (Scripted Pipeline) definition
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-    String script = "" +
-        "node {" +
-        "  createGitHubRelease(tag: 'v1.2.3', commitish: '00000')" +
-        "}";
+        job.setDefinition(new CpsFlowDefinition(script, true));
 
-    job.setDefinition(new CpsFlowDefinition(script, true));
+        WorkflowRun run = job.scheduleBuild2(0).get();
 
-    WorkflowRun run = job.scheduleBuild2(0).get();
+        j.assertBuildStatus(Result.FAILURE, run);
+        j.assertLogContains("credentialId cannot be null", run);
+    }
 
-    j.assertBuildStatus(Result.FAILURE, run);
-    j.assertLogContains("credentialId cannot be null", run);
-  }
+    @Test
+    public void executeBodyText() throws Exception {
+        SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
+        instance.getCredentials()
+                .add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("asdfas")));
+        instance.save();
 
-  @Test
-  public void executeBodyText() throws Exception {
-    SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
-    instance.getCredentials().add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("asdfas")));
-    instance.save();
+        final String script = loadScript("bodyText.groovy");
 
+        // Create a new Pipeline with the given (Scripted Pipeline) definition
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 
-    final String script = loadScript("bodyText.groovy");
+    @Test
+    public void executeBodyFile() throws Exception {
+        SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
+        instance.getCredentials()
+                .add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("asdfasd")));
+        instance.save();
 
-    // Create a new Pipeline with the given (Scripted Pipeline) definition
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-  }
+        final String script = loadScript("bodyFile.groovy");
 
+        WorkflowJob job = j.createProject(WorkflowJob.class);
 
-  @Test
-  public void executeBodyFile() throws Exception {
-    SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
-    instance.getCredentials().add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("asdfasd")));
-    instance.save();
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 
-    final String script = loadScript("bodyFile.groovy");
+    @Test
+    public void executeGenerateReleaseNotes() throws Exception {
+        SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
+        instance.getCredentials()
+                .add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("asdfasd")));
+        instance.save();
 
-    WorkflowJob job = j.createProject(WorkflowJob.class);
+        final String script = loadScript("generateReleaseNotes.groovy");
 
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-  }
+        WorkflowJob job = j.createProject(WorkflowJob.class);
 
-  @Test
-  public void executeGenerateReleaseNotes() throws Exception {
-    SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
-    instance.getCredentials().add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("asdfasd")));
-    instance.save();
-
-    final String script = loadScript("generateReleaseNotes.groovy");
-
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-  }
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 }

--- a/src/test/java/io/jenkins/plugins/github/release/ListReleaseStepTests.java
+++ b/src/test/java/io/jenkins/plugins/github/release/ListReleaseStepTests.java
@@ -27,73 +27,71 @@ package io.jenkins.plugins.github.release;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import hudson.util.Secret;
+import java.io.IOException;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-
 public class ListReleaseStepTests extends AbstractWireMockTests {
 
+    @Before
+    public void setupCredentials() throws IOException {
+        SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
+        instance.getCredentials()
+                .add(new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("adfadasdafdsa")));
+        instance.save();
+    }
 
+    @Test
+    public void listAllReleases() throws Exception {
+        final String script = loadScript("listAllReleases.groovy");
 
+        // Create a new Pipeline with the given (Scripted Pipeline) definition
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 
+    @Test
+    public void noDrafts() throws Exception {
+        final String script = loadScript("noDrafts.groovy");
 
-  @Before
-  public void setupCredentials() throws IOException {
-    SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
-    instance.getCredentials().add(new StringCredentialsImpl(CredentialsScope.GLOBAL, "a1234", "desc", Secret.fromString("adfadasdafdsa")));
-    instance.save();
-  }
+        // Create a new Pipeline with the given (Scripted Pipeline) definition
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 
-  @Test
-  public void listAllReleases() throws Exception {
-    final String script = loadScript("listAllReleases.groovy");
+    @Test
+    public void allDrafts() throws Exception {
+        final String script = loadScript("allDrafts.groovy");
 
-    // Create a new Pipeline with the given (Scripted Pipeline) definition
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-  }
-  @Test
-  public void noDrafts() throws Exception {
-    final String script = loadScript("noDrafts.groovy");
+        // Create a new Pipeline with the given (Scripted Pipeline) definition
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 
-    // Create a new Pipeline with the given (Scripted Pipeline) definition
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-  }
-  @Test
-  public void allDrafts() throws Exception {
-    final String script = loadScript("allDrafts.groovy");
+    @Test
+    public void tagPattern() throws Exception {
+        final String script = loadScript("tagPattern.groovy");
 
-    // Create a new Pipeline with the given (Scripted Pipeline) definition
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-  }
-  @Test
-  public void tagPattern() throws Exception {
-    final String script = loadScript("tagPattern.groovy");
+        // Create a new Pipeline with the given (Scripted Pipeline) definition
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 
-    // Create a new Pipeline with the given (Scripted Pipeline) definition
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-  }
+    @Test
+    public void latestSymantecVersion() throws Exception {
+        final String script = loadScript("latestSymantecVersion.groovy");
 
-  @Test
-  public void latestSymantecVersion() throws Exception {
-    final String script = loadScript("latestSymantecVersion.groovy");
-
-    // Create a new Pipeline with the given (Scripted Pipeline) definition
-    WorkflowJob job = j.createProject(WorkflowJob.class);
-    job.setDefinition(new CpsFlowDefinition(script, true));
-    j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
-
-  }
-
+        // Create a new Pipeline with the given (Scripted Pipeline) definition
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition(script, true));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0).get());
+    }
 }

--- a/src/test/java/io/jenkins/plugins/github/release/SymantecVersionReleaseComparatorTests.java
+++ b/src/test/java/io/jenkins/plugins/github/release/SymantecVersionReleaseComparatorTests.java
@@ -1,64 +1,40 @@
 package io.jenkins.plugins.github.release;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.Test;
 
 public class SymantecVersionReleaseComparatorTests {
 
-  Release release(String input) {
-    Release result = new Release(input);
-    return result;
-  }
+    Release release(String input) {
+        Release result = new Release(input);
+        return result;
+    }
 
-  @Test
-  public void sort() {
-    SymantecVersionReleaseComparator comparator = new SymantecVersionReleaseComparator();
+    @Test
+    public void sort() {
+        SymantecVersionReleaseComparator comparator = new SymantecVersionReleaseComparator();
 
-    List<String> expectedASC = List.of(
-        "1.0.0",
-        "V1.0.7",
-        "2.0.0",
-        "v2.0.1"
-    );
-    List<String> expectedDESC = List.of(
-        "v2.0.1",
-        "2.0.0",
-        "V1.0.7",
-        "1.0.0"
-    );
+        List<String> expectedASC = List.of("1.0.0", "V1.0.7", "2.0.0", "v2.0.1");
+        List<String> expectedDESC = List.of("v2.0.1", "2.0.0", "V1.0.7", "1.0.0");
 
-    List<String> asc = Stream.of(
-            "2.0.0",
-            "1.0.0",
-            "v2.0.1",
-            "V1.0.7"
-        )
-        .map(this::release)
-        .sorted(comparator)
-        .map(t->t.tagName)
-        .collect(Collectors.toList());
+        List<String> asc = Stream.of("2.0.0", "1.0.0", "v2.0.1", "V1.0.7")
+                .map(this::release)
+                .sorted(comparator)
+                .map(t -> t.tagName)
+                .collect(Collectors.toList());
 
-    assertEquals(expectedASC, asc);
-    comparator.ascending = false;
-    List<String> desc = Stream.of(
-            "2.0.0",
-            "1.0.0",
-            "v2.0.1",
-            "V1.0.7"
-        )
-        .map(this::release)
-        .sorted(comparator)
-        .map(e->e.tagName)
-        .collect(Collectors.toList());
+        assertEquals(expectedASC, asc);
+        comparator.ascending = false;
+        List<String> desc = Stream.of("2.0.0", "1.0.0", "v2.0.1", "V1.0.7")
+                .map(this::release)
+                .sorted(comparator)
+                .map(e -> e.tagName)
+                .collect(Collectors.toList());
 
-    assertEquals(expectedDESC, desc);
-
-
-  }
-
+        assertEquals(expectedDESC, desc);
+    }
 }

--- a/src/test/java/io/jenkins/plugins/github/release/SymantecVersionTests.java
+++ b/src/test/java/io/jenkins/plugins/github/release/SymantecVersionTests.java
@@ -1,40 +1,40 @@
 package io.jenkins.plugins.github.release;
 
-import org.junit.Test;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import org.junit.Test;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 public class SymantecVersionTests {
-  @TestFactory
-  public Stream<DynamicTest> of() {
-    Map<String, SymantecVersion> tests = new LinkedHashMap<>();
-    tests.put("0.0.0", new SymantecVersion(0, 0, 0));
-    tests.put("1.2.3", new SymantecVersion(1, 2, 3));
-    tests.put("V1.2.3", new SymantecVersion(1, 2, 3));
-    tests.put("3.2.1", new SymantecVersion(3, 2, 1));
-    tests.put("v3.2.1", new SymantecVersion(3, 2, 1));
+    @TestFactory
+    public Stream<DynamicTest> of() {
+        Map<String, SymantecVersion> tests = new LinkedHashMap<>();
+        tests.put("0.0.0", new SymantecVersion(0, 0, 0));
+        tests.put("1.2.3", new SymantecVersion(1, 2, 3));
+        tests.put("V1.2.3", new SymantecVersion(1, 2, 3));
+        tests.put("3.2.1", new SymantecVersion(3, 2, 1));
+        tests.put("v3.2.1", new SymantecVersion(3, 2, 1));
 
-    return tests.entrySet().stream().map(e -> dynamicTest(e.getKey(), () -> {
-      final SymantecVersion expected = e.getValue();
-      final SymantecVersion actual = SymantecVersion.of(e.getKey());
-      assertEquals("major", expected.major, actual.major);
-      assertEquals("minor", expected.minor, actual.minor);
-      assertEquals("revision", expected.revision, actual.revision);
-    }));
-  }
+        return tests.entrySet().stream()
+                .map(e -> dynamicTest(e.getKey(), () -> {
+                    final SymantecVersion expected = e.getValue();
+                    final SymantecVersion actual = SymantecVersion.of(e.getKey());
+                    assertEquals("major", expected.major, actual.major);
+                    assertEquals("minor", expected.minor, actual.minor);
+                    assertEquals("revision", expected.revision, actual.revision);
+                }));
+    }
 
-  @Test
-  public void incrementRevision() {
-    SymantecVersion input = new SymantecVersion(1, 0, 0);
-    SymantecVersion expected = new SymantecVersion(1, 0, 1);
-    SymantecVersion actual = input.incrementRevision();
-    assertEquals(expected, actual);
-  }
+    @Test
+    public void incrementRevision() {
+        SymantecVersion input = new SymantecVersion(1, 0, 0);
+        SymantecVersion expected = new SymantecVersion(1, 0, 1);
+        SymantecVersion actual = input.incrementRevision();
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/io/jenkins/plugins/github/release/WireMockRuleFactory.java
+++ b/src/test/java/io/jenkins/plugins/github/release/WireMockRuleFactory.java
@@ -1,37 +1,40 @@
 package io.jenkins.plugins.github.release;
-import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
-import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
+import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
 public class WireMockRuleFactory {
-  private String urlToMock = System.getProperty("wiremock.record");
+    private String urlToMock = System.getProperty("wiremock.record");
 
-  public WireMockRule getRule(int port) {
-    return getRule(wireMockConfig().port(port));
-  }
-
-  public WireMockRule getRule(Options options) {
-    if (urlToMock != null && !urlToMock.isEmpty()) {
-      return new WireMockRecorderRule(options, urlToMock);
-    } else {
-      return new WireMockRule(options);
+    public WireMockRule getRule(int port) {
+        return getRule(wireMockConfig().port(port));
     }
-  }
 
-  private class WireMockRecorderRule extends WireMockRule {
-    //needed for WireMockRule file location
-    private String mappingLocation = "src/test/resources";
-
-    public WireMockRecorderRule(Options options, String url) {
-      super(options);
-      this.stubFor(get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom(url)));
-      this.enableRecordMappings(new SingleRootFileSource(mappingLocation + "/mappings"),
-          new SingleRootFileSource(mappingLocation + "/__files"));
+    public WireMockRule getRule(Options options) {
+        if (urlToMock != null && !urlToMock.isEmpty()) {
+            return new WireMockRecorderRule(options, urlToMock);
+        } else {
+            return new WireMockRule(options);
+        }
     }
-  }
+
+    private class WireMockRecorderRule extends WireMockRule {
+        // needed for WireMockRule file location
+        private String mappingLocation = "src/test/resources";
+
+        public WireMockRecorderRule(Options options, String url) {
+            super(options);
+            this.stubFor(
+                    get(urlMatching(".*")).atPriority(10).willReturn(aResponse().proxiedFrom(url)));
+            this.enableRecordMappings(
+                    new SingleRootFileSource(mappingLocation + "/mappings"),
+                    new SingleRootFileSource(mappingLocation + "/__files"));
+        }
+    }
 }

--- a/src/test/resources/io/jenkins/plugins/github/release/CreateReleaseStepTests/api/mappings/mapping-repos_jcustenborder_xjc-kafka-connect-plugin_releases_generate_notes.json
+++ b/src/test/resources/io/jenkins/plugins/github/release/CreateReleaseStepTests/api/mappings/mapping-repos_jcustenborder_xjc-kafka-connect-plugin_releases_generate_notes.json
@@ -1,0 +1,33 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "name": "repos_jcustenborder_xjc-kafka-connect-plugin_releases_generate_notes",
+  "request": {
+    "url": "/repos/jcustenborder/xjc-kafka-connect-plugin/releases",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\"tag_name\":\"v1.2.3.4\",\"target_commitish\":\"17b5676aaab28e334c0a9befc86e7615a7539c32\",\"draft\":true,\"generate_release_notes\":true}",
+        "ignoreArrayOrder": true,
+        "ignoreExtraElements": true
+      }
+    ]
+  },
+  "response": {
+    "status": 201,
+    "body": "{\"url\":\"https://api.github.com/repos/jcustenborder/xjc-kafka-connect-plugin/releases/125264817\",\"assets_url\":\"https://api.github.com/repos/jcustenborder/xjc-kafka-connect-plugin/releases/125264817/assets\",\"upload_url\":\"https://uploads.github.com/repos/jcustenborder/xjc-kafka-connect-plugin/releases/125264817/assets{?name,label}\",\"html_url\":\"https://github.com/jcustenborder/xjc-kafka-connect-plugin/releases/tag/v1.2.3.4\",\"id\":125264817,\"author\":{\"login\":\"jcustenborder\",\"id\":209792},\"node_id\":\"RE_kwDOBwZ19s4Hd2Ow\",\"tag_name\":\"v1.2.3.4\",\"target_commitish\":\"17b5676aaab28e334c0a9befc86e7615a7539c32\",\"name\":\"v1.2.3.4\",\"draft\":true,\"prerelease\":false,\"created_at\":\"2023-10-16T16:07:33Z\",\"published_at\":null,\"assets\":[],\"tarball_url\":null,\"zipball_url\":null,\"body\":\"## What's Changed\\n\\n* Auto-generated release notes\"}",
+    "headers": {
+      "Server": "GitHub.com",
+      "Date": "Mon, 16 Oct 2023 16:07:33 GMT",
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "private, max-age=60, s-maxage=60",
+      "X-OAuth-Scopes": "repo, workflow",
+      "X-Accepted-OAuth-Scopes": "repo",
+      "Location": "https://api.github.com/repos/jcustenborder/xjc-kafka-connect-plugin/releases/125264817",
+      "X-GitHub-Media-Type": "github.v3; format=json",
+      "x-github-api-version-selected": "2022-11-28"
+    }
+  },
+  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "persistent": true,
+  "priority": 1
+}

--- a/src/test/resources/io/jenkins/plugins/github/release/CreateReleaseStepTests/generateReleaseNotes.groovy
+++ b/src/test/resources/io/jenkins/plugins/github/release/CreateReleaseStepTests/generateReleaseNotes.groovy
@@ -1,0 +1,13 @@
+package io.jenkins.plugins.github.release.CreateReleaseStepTests
+
+node {
+    createGitHubRelease(
+            credentialId: 'a1234',
+            githubServer: '%s',
+            repository: 'jcustenborder/xjc-kafka-connect-plugin',
+            tag: 'v1.2.3.4',
+            commitish: '17b5676aaab28e334c0a9befc86e7615a7539c32',
+            generateReleaseNotes: true,
+            draft: true
+    )
+}


### PR DESCRIPTION
This change allow to generate the release notes automatic as github is able to do

### Testing done

Deploy on a jenkins pipeline:

https://github.com/amarula/checks-jenkins/releases

```
if (branchParam != 'master' && isTag) {
    createGitHubRelease(
        credentialId: 'github-release-token',
        repository: 'amarula/checks-jenkins',
        tag: branchParam,
        commitish: tagCommitish,
        generateReleaseNotes: true,
    )
    uploadGithubReleaseAsset(
        credentialId: 'github-release-token',
        repository: 'amarula/checks-jenkins',
        tagName: branchParam,
        uploadAssets: [[filePath: jarPath]],
    )
}
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
